### PR TITLE
Add SetFrameID service

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,7 @@ add_service_files(
   SwitchMapPetition.srv
   SetElevatorPetition.srv
   MissionPetition.srv
+  SetFrameID.srv
 )
 
 ## Generate actions in the 'action' folder

--- a/srv/SetFrameID.srv
+++ b/srv/SetFrameID.srv
@@ -1,0 +1,4 @@
+string frame_id   # the new global frame_id
+---
+bool success   # indicate successful run of triggered service
+string message # informational, e.g. for error messages


### PR DESCRIPTION
Adds new service to change any frame_id.
- Request: string frame_id
- Response: bool success, string message

The initial idea was to add a standard SetString srv into robotnik_msgs, but using general services is not recommended due to lack of semantic meaning ([link to discourse](https://discourse.ros.org/t/suggestions-for-std-srvs/1079))