### PR TITLE
feat: extra estatus for the docking signal

### DIFF
--- a/msg/Status.msg
+++ b/msg/Status.msg
@@ -35,6 +35,7 @@ string OPERATION_STATE_MOVING=moving
 string OPERATION_STATE_ELEVATION_RAISE=raising_elevator
 string OPERATION_STATE_ELEVATION_LOWER=lowering_elevator
 string OPERATION_STATE_BATTERY_CHARGE=charging
+string OPERATION_STATE_DOCKING=dock_to_charge
 
 
 ###############################################################################################

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>robot_local_control_msgs</name>
-  <version>1.6.0</version>
+  <version>1.7.0</version>
   <description>The robot_local_control_msgs package</description>
 
   <maintainer email="mbosch@robotnik.es">Marc Bosch</maintainer>


### PR DESCRIPTION
This pull request introduces a new operation state for the system, specifically to represent when the robot is docking to charge. This helps clarify and distinguish between different charging-related states.

- Operation State Enhancements:
  * Added a new string constant `OPERATION_STATE_DOCKING` with the value `dock_to_charge` in the `Status.msg` file to represent the docking process for charging.